### PR TITLE
Fixing collision with names on strings count

### DIFF
--- a/reviewers/attr_no_duplication.go
+++ b/reviewers/attr_no_duplication.go
@@ -2,7 +2,6 @@ package reviewers
 
 import (
 	"io"
-	"strings"
 
 	"github.com/wawandco/milo/external/html"
 )
@@ -27,9 +26,9 @@ func (a AttrNoDuplication) Review(path string, r io.Reader) ([]Fault, error) {
 		}
 
 		tok := z.Token()
-		attrNames := a.inlineAttributesName(tok.Attr)
+		keys := map[string]bool{}
 		for _, attr := range tok.Attr {
-			if strings.Count(attrNames, attr.Key) > 1 {
+			if keys[attr.Key] {
 				fault = append(fault, Fault{
 					Reviewer: a.ReviewerName(),
 					Line:     tok.Line,
@@ -37,17 +36,10 @@ func (a AttrNoDuplication) Review(path string, r io.Reader) ([]Fault, error) {
 					Rule:     Rules["0010"],
 				})
 			}
-			attrNames = strings.ReplaceAll(attrNames, attr.Key, "")
+
+			keys[attr.Key] = true
 		}
 	}
 
 	return fault, nil
-}
-
-func (a AttrNoDuplication) inlineAttributesName(attributes []html.Attribute) string {
-	var attrNames []string
-	for _, atr := range attributes {
-		attrNames = append(attrNames, atr.Key)
-	}
-	return strings.Join(attrNames, ",")
 }

--- a/reviewers/attr_no_duplication_test.go
+++ b/reviewers/attr_no_duplication_test.go
@@ -69,6 +69,12 @@ func Test_AttrNoDuplication_Review(t *testing.T) {
 			content: `<a href="/company/5eaf45f1-74ee-443b-9e17-e30949935cb0/users" class="list-group-item list-group-item-action ERB">`,
 			fault:   []reviewers.Fault{},
 		},
+
+		{
+			name:    "srcset and src",
+			content: `<img class="logo" src="/assets/images/agnte_white_logo@2x" srcset="/assets/images/agnte_white_logo@2x.png 2x, /assets/images/agnte_white_logo.png 1x">`,
+			fault:   []reviewers.Fault{},
+		},
 	}
 
 	for _, tcase := range tcases {


### PR DESCRIPTION
This fixes a collision issue on the duplicate attribute name reviewer.