### PR TITLE
Skipping non html

### DIFF
--- a/cmd/review/review.go
+++ b/cmd/review/review.go
@@ -85,12 +85,17 @@ func (r *Runner) walkFn(path string, info os.FileInfo, err error) error {
 		return err
 	}
 
+	if filepath.Ext(path) != ".html" {
+		return nil
+	}
+
 	data = sanitizeERB(data)
 
 	for _, rev := range r.reviewers {
 		fileFaults, err := rev.Review(path, bytes.NewBuffer(data))
 		if err != nil {
 			fmt.Printf("[Warning] Error executing %v : %v", rev.ReviewerName(), err)
+
 			continue
 		}
 


### PR DESCRIPTION
Milo was analyzing all files and should only analyze those with extension .html. This Pr patches that issue.