### PR TITLE
Fixing typo and example on error

### DIFF
--- a/cmd/review/review.go
+++ b/cmd/review/review.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	ErrFaultsFound      = errors.New("faults found")
-	ErrInsufficientArgs = errors.New("please pass the folder to analize, p.e: milo run templates")
+	ErrInsufficientArgs = errors.New("please pass the folder to analyze, p.e: milo review templates")
 )
 
 // Runner is in charge of running the reviewers


### PR DESCRIPTION
Found a couple of typos on the error message when running milo without specifying the file or folder.